### PR TITLE
Feat-33: Implement delete organisation endpoint

### DIFF
--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -1,7 +1,7 @@
  import { NextFunction, Request, Response } from "express";
 import { OrgService } from "../services/OrgService";
 import validator from "validator";
-import { BadRequest, ResourceNotFound, ServerError, Unauthorized } from "../middleware";
+import { BadRequest, Forbidden, ResourceNotFound, ServerError, Unauthorized } from "../middleware";
 
 export class OrgController {
   private orgService: OrgService;
@@ -40,7 +40,7 @@ export const deleteOrganisation = async (req: Request, res: Response, next: Next
   try {
       const organisationService = new OrgService();
       const {orgId} = req.params;
-      const user_id = req.user.id;
+      const user_id = req.user.id; 
       
       if (!validator.isUUID(orgId)) {
           throw new BadRequest("Invalid organization ID format");
@@ -48,10 +48,11 @@ export const deleteOrganisation = async (req: Request, res: Response, next: Next
       const organisationExist = await organisationService.getOrganisation(orgId)
       if (!organisationExist) {
           throw new ResourceNotFound("Invalid organisation ID - Not found");
-      }
+      }      
       const isUserOrganization = organisationExist.userOrganizations.find(user => user.userId === user_id);
-      if(!isUserOrganization || isUserOrganization.role !== "admin") {
-          throw new Unauthorized("User not authorized to delete this organization")
+      
+      if(!isUserOrganization || (isUserOrganization && isUserOrganization.role !== "admin")) {
+          throw new Forbidden("User not authorized to delete this organization")
       }
       const deletedOrg = await organisationService.deleteOrganisation(orgId)
       if (!deletedOrg) {

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -42,7 +42,7 @@ export const authMiddleware = async (
         });
       }
       const user = await User.findOne({
-        where: { email: decoded["email"] as string },
+        where: { id: decoded["userId"] as string },
       });
       if (!user) {
         return res.status(401).json({
@@ -50,6 +50,8 @@ export const authMiddleware = async (
           message: "Invalid token",
         });
       }
+      console.log(user);
+      
       req.user = user;
       next();
     });

--- a/src/routes/organisation.ts
+++ b/src/routes/organisation.ts
@@ -1,5 +1,6 @@
 import Router from "express";
-import { OrgController } from "../controllers/OrgController";
+import { deleteOrganisation, OrgController } from "../controllers/OrgController";
+import { authMiddleware } from "../middleware";
 
 const orgRouter = Router();
 const orgController = new OrgController();
@@ -8,4 +9,8 @@ orgRouter.delete(
   "/organizations/:org_id/users/:user_id",
   orgController.removeUser.bind(orgController),
 );
+
+orgRouter.delete("/organisations/:orgId", authMiddleware, deleteOrganisation);
+
+
 export { orgRouter };

--- a/src/services/OrgService.ts
+++ b/src/services/OrgService.ts
@@ -2,6 +2,7 @@ import { Organization } from "../models/organization";
 import AppDataSource from "../data-source";
 import { User } from "../models/user";
 import { IOrgService, IUserService } from "../types";
+import { UserOrganization } from "../models/user-organisation";
 
 export class OrgService implements IOrgService {
   public async removeUser(
@@ -42,5 +43,47 @@ export class OrgService implements IOrgService {
     await organizationRepository.save(organization);
 
     return user;
+  }
+
+  public async deleteOrganisation(id: string): Promise<Organization | null> {
+    try {
+      const organizationRepository = AppDataSource.getRepository(Organization);
+      const organization = await organizationRepository.findOne({
+        where: { id },
+        relations: ['userOrganizations']
+      });
+
+
+      if (!organization) return null
+
+      await AppDataSource.transaction(async transactionalEntityManager => {
+        // Delete related user organizations
+        await transactionalEntityManager.delete(UserOrganization, { organizationId: id });
+  
+        // Delete the organization
+        await transactionalEntityManager.remove(Organization, organization);
+      });
+
+
+      return organization;
+      // return null;
+
+    } catch(error) {
+      console.log(error);
+      
+      throw error
+    }
+  }
+
+  public async getOrganisation(id: string): Promise<Organization | null> {
+    const organizationRepository = AppDataSource.getRepository(Organization);
+    const organization = await organizationRepository.findOne({
+      where: { id },
+      relations: ["userOrganizations"]
+    });
+    
+    if (!organization) return null
+
+    return organization;
   }
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,4 +1,4 @@
-import { User } from "../models";
+import { Organization, User } from "../models";
 
 export interface IUserService {
   getUserById(id: string): Promise<User | null>;
@@ -7,6 +7,8 @@ export interface IUserService {
 
 export interface IOrgService {
   removeUser(org_id: string, user_id: string): Promise<User | null>;
+  deleteOrganisation(id: string): Promise<Organization | null>;
+  getOrganisation(is: string): Promise<Organization | null>
 }
 
 export interface IRole {
@@ -44,7 +46,9 @@ export interface ICreateOrganisation {
 }
 
 export interface IOrganisationService {
-  createOrganisation(payload: ICreateOrganisation, userId: string): Promise<unknown>;
+  createOrganisation(payload: ICreateOrganisation, userId: string): Promise<{
+    newOrganisation: Partial<Organization>;
+  }>;
 }
 
 declare module "express-serve-static-core" {


### PR DESCRIPTION
### Description
This PR introduces a new endpoint to delete an organization by its ID. The endpoint is protected, requiring user authentication and ownership validation. The delete operation is performed as a hard delete, marking the organization as deleted and also user organisation data related to the organization.


### Changes
* Added a DELETE api/v1/organisations/:orgId endpoint.
* Integrated validation for the organisation ID
* Validate delete access for user attempting to delete organisation
* Implemented hard delete functionality for the organization resource and related association data related to the organization.
* Updated authMiddleware to verify JWT based on the userId field instead of email.

### Documentation

###DELETE /organisations/
Deletes an organization by its ID. This operation is a hard delete, meaning the organisation is marked as deleted along with all related user-rgnaisation association records.

#### Request
* URL: api/v1/organiz=sations/:orgId
* Method: DELETE
* Headers:
* Authorization: Bearer <token>
* Params:
         orgId: UUID of the organisation to delete.

### Response

* 204 OK: Organisation Deleted
![Screenshot (116)](https://github.com/user-attachments/assets/b85dc086-fea2-401b-908c-f2de2844e040)

* 400 BAD REQUEST: Invalid Organisation Id
![Screenshot (117)](https://github.com/user-attachments/assets/cea4181e-8368-4ee0-9334-f04c981bc347)

* 401 Unauthorized: No token provided or invalid token
![Screenshot (118)](https://github.com/user-attachments/assets/a6eee735-cec8-46f4-a827-5fc796d2a911)

*403 Forbidden: User does not have permission to delete the organisation.
![Screenshot (119)](https://github.com/user-attachments/assets/430b815a-4014-419d-a19f-408333d24662)

* 404 Not Found: Organization not found or user not authorized.
![Screenshot (120)](https://github.com/user-attachments/assets/5d8cd2f2-00d7-435e-9062-6ffdac9a0699)


