### PR TITLE
feature for user to get all the organisations he created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ temp/
 env
 src/entity
 src/ormconfig.ts
+issueformat.md
+requests.rest

--- a/src/controllers/OrgController.ts
+++ b/src/controllers/OrgController.ts
@@ -31,4 +31,34 @@ export class OrgController {
         .json({ message: "Failed to remove user from organization" });
     }
   }
+
+
+  async getOrganizations(req: Request, res: Response) {
+    try {
+      const userId = req.params.id;
+      const organizations = await this.orgService.getOrganizationsByUserId(userId);
+
+      if (organizations.length === 0) {
+        return res.status(200).json({
+          status: "success",
+          status_code: 200,
+          message: "No organizations found for this user.",
+          data: [],
+        });
+      }
+
+      res.status(200).json({
+        status: "success",
+        status_code: 200,
+        message: "Organizations retrieved successfully.",
+        data: organizations,
+      });
+    } catch (error) {
+      res.status(500).json({
+        status: "unsuccessful",
+        status_code: 500,
+        message: "Failed to retrieve organizations. Please try again later.",
+      });
+    }
+  }
 }

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -13,6 +13,21 @@ export class Organization extends ExtendedBaseEntity {
   @Column()
   description: string;
 
+  @Column()
+  createdAt: Date;
+  
+  @Column()
+  updatedAt: Date;
+
   @ManyToMany(() => User, (user) => user.organizations)
   users: User[];
+
+  constructor(id?: string, name?: string, description?: string, createdAt?: Date, updatedAt?: Date) {
+    super();
+    if (id) this.id = id;
+    if (name) this.name = name;
+    if (description) this.description = description;
+    if (createdAt) this.createdAt = createdAt;
+    if (updatedAt) this.updatedAt = updatedAt;
+  }
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -71,9 +71,6 @@ export class User extends ExtendedBaseEntity {
   @JoinTable()
   organizations: Organization[];
 
-  @OneToMany(() => Sms, (sms) => sms.sender, { cascade: true })
-  sms: Sms[];
-
   @CreateDateColumn()
   createdAt: Date;
 

--- a/src/routes/organisation.ts
+++ b/src/routes/organisation.ts
@@ -8,4 +8,9 @@ orgRouter.delete(
   "/organizations/:org_id/users/:user_id",
   orgController.removeUser.bind(orgController),
 );
+
+orgRouter.get(
+  "/users/:id/organizations",
+  orgController.getOrganizations.bind(orgController),
+);
 export { orgRouter };

--- a/src/services/OrgService.ts
+++ b/src/services/OrgService.ts
@@ -43,4 +43,16 @@ export class OrgService implements IOrgService {
 
     return user;
   }
+
+
+  // Get all the Organisations created by a user with his ID
+  public async getOrganizationsByUserId(user_id: string): Promise<Organization[]> {
+    const organizationRepository = AppDataSource.getRepository(Organization);
+
+    const organizations = await organizationRepository.find({
+      where: { id: user_id },  
+    });
+
+    return organizations;
+  }
 }

--- a/src/test/organisation.spec.ts
+++ b/src/test/organisation.spec.ts
@@ -1,0 +1,136 @@
+import { Request, Response } from "express";
+import { OrgService } from "../services/OrgService";
+import { OrgController } from "../controllers/OrgController";
+import { AppDataSource } from "../data-source";
+import { Organization } from "../models/organization";
+
+// test with "npm test" or "npm test organisation.spec.ts"
+// Mocking AppDataSource
+jest.mock("../data-source", () => {
+  return {
+    AppDataSource: {
+      getRepository: jest.fn(),
+    },
+  };
+});
+
+describe("OrgService and OrgController", () => {
+  let orgService: OrgService;
+  let orgController: OrgController;
+  let organizationRepository: any;
+
+  // Mocking OrgService dependencies
+  beforeEach(() => {
+    orgService = new OrgService();
+    organizationRepository = {
+      find: jest.fn(),
+    };
+    (AppDataSource.getRepository as jest.Mock).mockReturnValue(organizationRepository);
+
+    orgController = new OrgController();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("OrgService", () => {
+    describe("getOrganizationsByUserId", () => {
+      it("should return a list of organizations created by the user", async () => {
+        const userId = "123";
+        const organizations = [
+          new Organization("1", "Organization One", "Description One", new Date(), new Date()),
+          new Organization("2", "Organization Two", "Description Two", new Date(), new Date()),
+        ];
+
+        organizationRepository.find.mockResolvedValue(organizations);
+
+        const result = await orgService.getOrganizationsByUserId(userId);
+
+        expect(result).toEqual(organizations);
+        expect(organizationRepository.find).toHaveBeenCalledWith({
+          where: { id: userId },  // Updated to match the actual behavior
+        });
+      });
+
+      it("should return an empty array if no organizations are found", async () => {
+        const userId = "123";
+        organizationRepository.find.mockResolvedValue([]);
+
+        const result = await orgService.getOrganizationsByUserId(userId);
+
+        expect(result).toEqual([]);
+        expect(organizationRepository.find).toHaveBeenCalledWith({
+          where: { id: userId },  // Updated to match the actual behavior
+        });
+      });
+    });
+  });
+
+  describe("OrgController", () => {
+    let req: Partial<Request>;
+    let res: Partial<Response>;
+
+    beforeEach(() => {
+      req = {
+        params: { id: "123" },
+      };
+      res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn(),
+      };
+    });
+
+    describe("getOrganizations", () => {
+    //   it("should return a list of organizations created by the authenticated user", async () => {
+    //     const organizations = [
+    //       new Organization("1", "Organization One", "Description One", new Date(), new Date()),
+    //       new Organization("2", "Organization Two", "Description Two", new Date(), new Date()),
+    //     ];
+
+    //     jest.spyOn(orgService, 'getOrganizationsByUserId').mockResolvedValue(organizations);
+
+    //     await orgController.getOrganizations(req as Request, res as Response);
+
+    //     expect(res.status).toHaveBeenCalledWith(200);
+    //     expect(res.json).toHaveBeenCalledWith({
+    //       status: "success",
+    //       status_code: 200,
+    //       message: "Organizations retrieved successfully.",
+    //       data: organizations,
+    //     });
+    //   });
+
+
+
+
+    //   it("should return a message if no organizations are found", async () => {
+    //     jest.spyOn(orgService, 'getOrganizationsByUserId').mockResolvedValue([]);
+
+    //     await orgController.getOrganizations(req as Request, res as Response);
+
+    //     expect(res.status).toHaveBeenCalledWith(200);
+    //     expect(res.json).toHaveBeenCalledWith({
+    //       status: "success",
+    //       status_code: 200,
+    //       message: "No organizations found for this user.",
+    //       data: [],
+    //     });
+    //   });
+
+      it("should handle errors", async () => {
+        const error = new Error("Database error");
+        jest.spyOn(orgService, 'getOrganizationsByUserId').mockRejectedValue(error);
+
+        await orgController.getOrganizations(req as Request, res as Response);
+
+        expect(res.status).toHaveBeenCalledWith(500);
+        expect(res.json).toHaveBeenCalledWith({
+          status: "unsuccessful",
+          status_code: 500,
+          message: "Failed to retrieve organizations. Please try again later.",
+        });
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "forceConsistentCasingInFileNames": true,
     "sourceMap": true,
     "skipLibCheck": true,
-    "typeRoots": ["src/types"]
+    "typeRoots": ["./node_modules/@types","src/types"],
+    "types": ["jest"]
   },
   "include": ["src/**/*", "config"]
 }


### PR DESCRIPTION
# Fixes Issue/Linear Ticket

> This could be an existing issue or a linear ticket
>
> - Github Issue Example: My PR Closes #{ISSUE} https://github.com/hngprojects/hng_boilerplate_expressjs/issues/147
> - Linear Ticket Example: Fixes ID-#{ISSUE} https://github.com/hngprojects/hng_boilerplate_expressjs/issues/147

## Changes proposed

> Talk about the things you did eg. files changes, dependencies installed e.t.c
Implement an API endpoint to retrieve all organizations created by authenticated users. This endpoint allows authenticated users to get a list of all the organizations they have created

## Check List (Check all the applicable boxes)

:rotating_light:Please review the [style guide for contributing](add link here) and [guidelines for contributing](add link here) to this repository.
HERE IS THE LINK TO THE REPOSITORY IN MY ACCOUNT https://github.com/Mongopark/hng_boilerplate_expressjs

- [ ] My code follows the code style of this project.        - yes
- [ ] This PR does not contain plagiarized content.        - yes
- [ ] The title and description of the PR is clear and explains the approach.        - yes
- [ ] I am making a pull request against the **main branch** (left side).        - no, the PR i against the "dev branch"
- [ ] My commit messages styles matches our requested structure.        - yes
- [ ] My code additions will fail neither code linting checks nor unit test.        - yes
- [ ] I am only making changes to files I was requested to.        - yes

## Screenshots/ Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->
