### PR TITLE
fix: Ensure user profile details are returned on login

### DIFF
--- a/src/models/profile.ts
+++ b/src/models/profile.ts
@@ -1,4 +1,5 @@
-import { Column, Entity } from "typeorm";
+import { Column, Entity, OneToOne } from "typeorm";
+import { User } from ".";
 import ExtendedBaseEntity from "./base-entity";
 import { IsEmail } from "class-validator";
 import { getIsInvalidMessage } from "../utils";
@@ -38,4 +39,7 @@ export class Profile extends ExtendedBaseEntity {
 
   @Column({ nullable: true })
   profile_pic_url: string;
+
+  @OneToOne(() => User, (user) => user.profile)
+  user: User;
 }

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -71,7 +71,7 @@ export class User extends ExtendedBaseEntity {
   })
   user_type: UserType;
 
-  @OneToOne(() => Profile, (profile) => profile.id)
+  @OneToOne(() => Profile, (profile) => profile.user, { cascade: true, eager: true })
   @JoinColumn({ name: "profile_id" })
   profile: Profile;
 

--- a/src/services/authservice.ts
+++ b/src/services/authservice.ts
@@ -167,6 +167,7 @@ export class AuthService implements IAuthService {
     try {
       const user = await this.usersRepository.findOne({
         where: { email },
+        relations: ["profile"],
       });
 
       if (!user) {


### PR DESCRIPTION
# Fixes Issue/Linear Ticket

> This could be an existing issue or a linear ticket
>
> - Github Issue Example: My PR Closes #{32}
> - Linear Ticket Example: Fixes ID-#{ISSUE}

## Changes proposed

- Established correct `OneToOne` relationship between `User` and `Profile` entities in the `User` and `Profile` models.
- Modified the `login` method in `authservice.ts` to fetch profile details along with the user.
- Ensured `avatar_url` and `username` are included in the login response.



:rotating_light:Please review the [style guide for contributing](add link here) and [guidelines for contributing](add link here) to this repository.

- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.
- [x] I am making a pull request against the **main branch** (left side).
- [x] My commit messages styles matches our requested structure.
- [x] My code additions will fail neither code linting checks nor unit test.
- [x] I am only making changes to files I was requested to.

## Screenshots/ Videos

<!-- If the changes are static page changes or UI changes add screenshots -->
<!-- If the changes involve implementing a functionality or working with apis, include a video
detailing how to implement the functionality and the request to the api and responses from the api endpoint-->
<!-- Add all the screenshots/videos which support your changes i.e before your change and after your change -->
