### PR TITLE
Feat: API Endpoint for creating products

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -19,6 +19,7 @@ import {
   contactRouter,
   orgRouter,
 } from "./routes";
+import { productRouter } from "./routes/product";
 import ServerAdapter from "./views/bull-board";
 
 const app: Express = express();
@@ -60,6 +61,7 @@ app.use("/api/v1", notificationSettingRoute);
 app.use("/api/v1", notificationsRoute);
 app.use("/api/v1", contactRouter);
 app.use("/api/v1", orgRouter);
+app.use("/api/v1", productRouter);
 
 app.use(routeNotFound);
 app.use(errorHandler);

--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -1,0 +1,111 @@
+import { Request, Response } from "express";
+import { ProductService } from "../services/product";
+import asyncHandler from "../middleware/asyncHandler";
+
+class ProductController {
+  private productService: ProductService;
+
+  constructor() {
+    this.productService = new ProductService();
+  }
+
+  /**
+   * @openapi
+   * tags:
+   *   - name: Product API
+   *     description: Product API related routes
+   */
+
+  /**
+   * @openapi
+   * /api/v1/organisation/{org_id}/product:
+   *   post:
+   *     tags:
+   *       - Product API
+   *     summary: Create a new product
+   *     description: Create a new product for organisations.
+   *     parameters:
+   *       - name: org_id
+   *         in: path
+   *         required: true
+   *         description: ID of the organisation
+   *         schema:
+   *           type: string
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               name:
+   *                 type: string
+   *               description:
+   *                 type: string
+   *               category:
+   *                 type: string
+   *               price:
+   *                 type: number
+   *               quantity:
+   *                 type: number
+   *               image:
+   *                 type: string
+   *               is_deleted:
+   *                 type: boolean
+   *             required:
+   *               - name
+   *               - price
+   *               - quantity
+   *     responses:
+   *       201:
+   *         description: Product created successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 status:
+   *                   type: string
+   *                   example: "success"
+   *                 message:
+   *                   type: string
+   *                   example: "Product created successfully"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     id:
+   *                       type: string
+   *                     name:
+   *                       type: string
+   *                     description:
+   *                       type: string
+   *                     price:
+   *                       type: number
+   *                     status:
+   *                       type: string
+   *                     is_deleted:
+   *                       type: boolean
+   *                     quantity:
+   *                       type: number
+   *                     created_at:
+   *                       type: string
+   *                       format: date-time
+   *                     updated_at:
+   *                       type: string
+   *                       format: date-time
+   *       400:
+   *         description: Invalid input or missing organisation ID
+   *       409:
+   *         description: Server error
+   */
+  public createProduct = asyncHandler(async (req: Request, res: Response) => {
+    const id = req.params.org_id;
+    const product = req.body;
+    const newProduct = await this.productService.createProduct(id, product);
+    res
+      .status(201)
+      .json({ message: "Product created successfully", data: newProduct });
+  });
+}
+
+export { ProductController };

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -17,18 +17,18 @@ const AppDataSource = new DataSource({
   entities: ["src/models/**/*.ts"],
   migrations: ["src/migrations/**/*.ts"],
   migrationsTableName: "migrations",
-  ...(isDevelopment
-    ? {
-        ssl: {
-          rejectUnauthorized: false,
-        },
-        extra: {
-          ssl: {
-            rejectUnauthorized: false,
-          },
-        },
-      }
-    : {}),
+  //...(isDevelopment
+  //? {
+  //ssl: {
+  //rejectUnauthorized: false,
+  //},
+  //extra: {
+  //ssl: {
+  //rejectUnauthorized: false,
+  //},
+  //},
+  //}
+  //: {}),
 });
 
 export async function initializeDataSource() {

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -17,18 +17,18 @@ const AppDataSource = new DataSource({
   entities: ["src/models/**/*.ts"],
   migrations: ["src/migrations/**/*.ts"],
   migrationsTableName: "migrations",
-  //...(isDevelopment
-  //? {
-  //ssl: {
-  //rejectUnauthorized: false,
-  //},
-  //extra: {
-  //ssl: {
-  //rejectUnauthorized: false,
-  //},
-  //},
-  //}
-  //: {}),
+  ...(isDevelopment
+  ? {
+  ssl: {
+  rejectUnauthorized: false,
+  },
+  extra: {
+  ssl: {
+  rejectUnauthorized: false,
+  },
+  },
+  }
+  : {}),
 });
 
 export async function initializeDataSource() {

--- a/src/models/organization.ts
+++ b/src/models/organization.ts
@@ -10,6 +10,7 @@ import {
 import { User } from ".";
 import { v4 as uuidv4 } from "uuid";
 import { UserOrganization } from "./user-organization";
+import { Product } from "./product";
 import ExtendedBaseEntity from "./base-entity";
 
 @Entity()
@@ -58,6 +59,9 @@ export class Organization extends ExtendedBaseEntity {
     (userOrganization) => userOrganization.organization,
   )
   userOrganizations: UserOrganization[];
+
+  @OneToMany(() => Product, (product) => product.org, { cascade: true })
+  products: Product[];
 
   @BeforeInsert()
   generateSlug() {

--- a/src/models/product.ts
+++ b/src/models/product.ts
@@ -1,0 +1,57 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from "typeorm";
+import { Organization } from "./organization";
+import ExtendedBaseEntity from "../models/base-entity";
+
+export enum StockStatusType {
+  IN_STOCK = "in stock",
+  OUT_STOCK = "out of stock",
+  LOW_STOCK = "low on stock",
+}
+
+export enum ProductSizeType {
+  SMALL = "Small",
+  STANDARD = "Standard",
+  LARGE = "Large",
+}
+
+@Entity()
+export class Product extends ExtendedBaseEntity {
+  @Column({ type: "text", nullable: false })
+  name: string;
+
+  @Column({ type: "text", nullable: true })
+  description: string;
+
+  @Column({ type: "text", nullable: true })
+  category: string;
+
+  @Column({ type: "text", nullable: true })
+  image: string;
+
+  @Column({ type: "int", nullable: false, default: 0 })
+  price: number;
+
+  @Column({ type: "int", nullable: false, default: 0 })
+  quantity: number;
+
+  @Column({ nullable: true, default: false })
+  is_deleted: boolean;
+
+  @Column({
+    type: "enum",
+    enum: ProductSizeType,
+    default: ProductSizeType.STANDARD,
+  })
+  size: ProductSizeType;
+
+  @Column({
+    type: "enum",
+    enum: StockStatusType,
+    default: StockStatusType.OUT_STOCK,
+  })
+  stock_status: StockStatusType;
+
+  // To be implemented when organization is created.
+  @ManyToOne(() => Organization, (org) => org.products)
+  org: Organization;
+}

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -1,11 +1,17 @@
 import { Router } from "express";
 import { ProductController } from "../controllers/productController";
+import { authMiddleware } from "../middleware";
 
-const router = Router();
+console.log("ProductController:", ProductController);
+console.log("authMiddleware:", authMiddleware);
 
+const productRouter = Router();
 const productController = new ProductController();
 
-// Define routes for products
-router.post("/organizations/:id/products", productController.createProduct);
+productRouter.post(
+  "/organizations/:id/products",
+  authMiddleware,
+  (req, res, next) => productController.createProduct(req, res, next),
+);
 
-export default router;
+export { productRouter };

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -13,10 +13,4 @@ productRouter.post(
   authMiddleware,
   productController.createProduct,
 );
-productRouter.get(
-  "/organizations/:id/products/search",
-  authMiddleware,
-  productController.searchProduct,
-);
-
 export { productRouter };

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -11,7 +11,12 @@ const productController = new ProductController();
 productRouter.post(
   "/organizations/:id/products",
   authMiddleware,
-  (req, res, next) => productController.createProduct(req, res, next),
+  productController.createProduct,
+);
+productRouter.get(
+  "/organizations/:id/products/search",
+  authMiddleware,
+  productController.searchProduct,
 );
 
 export { productRouter };

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { ProductController } from "../controllers/productController";
+
+const router = Router();
+
+const productController = new ProductController();
+
+// Define routes for products
+router.post("/organizations/:id/products", productController.createProduct);
+
+export default router;

--- a/src/schemas/product.ts
+++ b/src/schemas/product.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const productSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  description: z.string().optional(),
+  category: z.string().optional(),
+  price: z.number().min(1, "Price is required"),
+  image: z.string().optional(),
+  quantity: z.number().min(1, "Quantity is required"),
+});
+
+export type ProductSchema = z.infer<typeof productSchema>;
+export default { productSchema };

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -1,0 +1,108 @@
+import { Repository } from "typeorm";
+import { Product, StockStatusType } from "../models/product";
+import AppDataSource from "../data-source";
+import { ProductSchema } from "../schemas/product";
+import { InvalidInput, ResourceNotFound, ServerError } from "../middleware";
+import { Organization } from "../models/organization";
+
+export class ProductService {
+  private productRepository: Repository<Product>;
+  private organizationRepository: Repository<Organization>;
+
+  private entities: {
+    [key: string]: {
+      repo: Repository<any>;
+      name: string;
+    };
+  };
+
+  constructor() {
+    this.productRepository = AppDataSource.getRepository(Product);
+    this.organizationRepository = AppDataSource.getRepository(Organization);
+
+    this.entities = {
+      product: {
+        repo: this.productRepository,
+        name: "Product",
+      },
+      organization: {
+        repo: this.organizationRepository,
+        name: "Organization",
+      },
+    };
+  }
+
+  private async checkEntities(
+    entitiesToCheck: {
+      [key: string]: string;
+    } = { product: "" },
+  ): Promise<{ [key: string]: any }> {
+    const foundEntities: { [key: string]: any } = {};
+
+    for (const [entityKey, id] of Object.entries(entitiesToCheck)) {
+      const entity = this.entities[entityKey];
+      if (!entity) {
+        throw new InvalidInput(`Invalid entity type: ${entityKey}`);
+      }
+
+      if (!id) {
+        throw new InvalidInput(`${entity.name} ID not provided`);
+      }
+
+      const found = await entity.repo.findOne({ where: { id } });
+      if (!found) {
+        throw new ResourceNotFound(`${entity.name} with id ${id} not found`);
+      }
+
+      foundEntities[entityKey] = found;
+    }
+
+    return foundEntities;
+  }
+
+  private async calculateProductStatus(
+    quantity: number,
+  ): Promise<StockStatusType> {
+    if (quantity === 0) {
+      return StockStatusType.OUT_STOCK;
+    }
+    return quantity >= 5 ? StockStatusType.IN_STOCK : StockStatusType.LOW_STOCK;
+  }
+
+  public async createProduct(orgId: string, new_Product: ProductSchema) {
+    const { organization } = await this.checkEntities({ organization: orgId });
+    if (!organization) {
+      throw new ServerError("Invalid organisation credentials");
+    }
+
+    const newProduct = this.productRepository.create(new_Product);
+    newProduct.org = organization;
+    newProduct.stock_status = await this.calculateProductStatus(
+      new_Product.quantity ?? 0,
+    );
+
+    const product = await this.productRepository.save(newProduct);
+    if (!product) {
+      throw new ServerError(
+        "An unexpected error occurred. Please try again later.",
+      );
+    }
+
+    return {
+      status_code: 201,
+      status: "success",
+      message: "Product created successfully",
+      data: {
+        id: product.id,
+        name: product.name,
+        description: product.description,
+        price: product.price,
+        status: product.stock_status,
+        is_deleted: product.is_deleted,
+        quantity: product.quantity,
+        created_at: product.created_at,
+        updated_at: product.updated_at,
+      },
+    };
+  }
+}

--- a/src/test/product.spec.ts
+++ b/src/test/product.spec.ts
@@ -1,0 +1,136 @@
+import { ProductService } from "../services/product";
+import { Repository } from "typeorm";
+import { Product, StockStatusType } from "../models/product";
+import { ProductSchema } from "../schemas/product";
+import { Organization } from "../models/organization";
+import { ServerError, ResourceNotFound } from "../middleware";
+
+jest.mock("../utils", () => ({
+  getIsInvalidMessage: jest
+    .fn()
+    .mockImplementation((field: string) => `${field} is invalid`),
+}));
+
+jest.mock("../data-source", () => ({
+  getRepository: jest.fn().mockImplementation((entity) => ({
+    create: jest.fn().mockReturnValue({}),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    createQueryBuilder: jest.fn(() => ({
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      skip: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getManyAndCount: jest.fn().mockReturnValue([[], 0]),
+    })),
+  })),
+}));
+
+describe("ProductService", () => {
+  let productService: ProductService;
+  let productRepository: Repository<Product>;
+  let organizationRepository: Repository<Organization>;
+
+  beforeEach(() => {
+    productService = new ProductService();
+    productRepository = productService["productRepository"];
+    organizationRepository = productService["organizationRepository"];
+  });
+
+  describe("createProducts", () => {
+    it("should create a product successfully", async () => {
+      // Mock data
+      const mockOrgId = "1";
+      const mockProduct: ProductSchema = {
+        name: "Test Product",
+        description: "This is a test product",
+        price: 50,
+        quantity: 50,
+      };
+      const mockOrganization = { id: "1", name: "Test Organization" };
+      const mockCreatedProduct = {
+        ...mockProduct,
+        id: "1",
+        stock_status: StockStatusType.IN_STOCK,
+      };
+
+      productService["checkEntities"] = jest
+        .fn()
+        .mockResolvedValue({ organization: mockOrganization });
+      productRepository.create = jest.fn().mockReturnValue(mockCreatedProduct);
+      productRepository.save = jest.fn().mockResolvedValue(mockCreatedProduct);
+      organizationRepository.findOne = jest
+        .fn()
+        .mockResolvedValue(mockOrganization);
+      productService["calculateProductStatus"] = jest
+        .fn()
+        .mockResolvedValue(StockStatusType.IN_STOCK);
+
+      const result = await productService.createProduct(mockOrgId, mockProduct);
+      expect(result.status_code).toEqual(201);
+      expect(result.status).toEqual("success");
+      expect(result.message).toEqual("Product created successfully");
+      expect(result.data.name).toEqual(mockProduct.name);
+      expect(result.data.description).toEqual(mockProduct.description);
+      expect(result.data.price).toEqual(mockProduct.price);
+      expect(result.data.quantity).toEqual(mockProduct.quantity);
+      expect(result.data.status).toEqual(StockStatusType.IN_STOCK);
+    });
+
+    it("should throw an error when credentials are invalid", async () => {
+      const mockOrgId = "nonexistentOrg";
+      const mockProduct: ProductSchema = {
+        name: "Test Product",
+        description: "This is a test product",
+        price: 50,
+        quantity: 10,
+      };
+
+      productService["checkEntities"] = jest
+        .fn()
+        .mockResolvedValue({ organization: undefined });
+      await expect(
+        productService.createProduct(mockOrgId, mockProduct),
+      ).rejects.toThrow(ServerError);
+    });
+
+    it("should throw an error when product data is invalid", async () => {
+      const mockOrgId = "1";
+      const invalidProduct: ProductSchema = {
+        name: "",
+        description: "This is a test product",
+        price: -10,
+        quantity: 50,
+      };
+      const mockOrganization = { id: "1", name: "Test Organization" };
+
+      productService["checkEntities"] = jest
+        .fn()
+        .mockResolvedValue({ organization: mockOrganization });
+
+      await expect(
+        productService.createProduct(mockOrgId, invalidProduct),
+      ).rejects.toThrow(Error);
+    });
+
+    it("should throw a server error when product creation fails", async () => {
+      const mockOrgId = "1";
+      const mockProduct: ProductSchema = {
+        name: "Test Product",
+        description: "This is a test product",
+        price: 50,
+        quantity: 10,
+      };
+
+      productService["checkEntities"] = jest.fn().mockResolvedValue({});
+      productRepository.create = jest.fn().mockReturnValue(mockProduct);
+      productRepository.save = jest
+        .fn()
+        .mockRejectedValue(new Error("Database error"));
+
+      await expect(
+        productService.createProduct(mockOrgId, mockProduct),
+      ).rejects.toThrow(ServerError);
+    });
+  });
+});


### PR DESCRIPTION
## Description:
This PR introduces a new endpoint to create products in an organization

## How should this be manually tested?
Send a POST request to `/organizations/:id/products`

```json
{
  "name": "string",
  "description": "string",
  "category": "string",
  "price": "number",
  "quantity": "number",
  "image": "string",
  "is_deleted": "boolean"
}
```
- Replace :id with the actual organization ID.
- Ensure the request body adheres to the schema with required fields: name, price, quantity.

## Checklist of what you did:
Implement POST `/api/v1/organizations/:id/products` endpoint
- [x] The endpoint should accept HTTP POST request
- [x] Added validation to check if the `org_id` and product data are valid before proceeding with product creation.
- [x]  OpenAPI documentation to ensure it accurately reflects the endpoint's functionality.
- [x] Ensure authentication using JWT tokens
- [x] Write unit tests for the product endpoint

## Reference Issues
[FEAT] API Endpoint for creating products #145 