### PR TITLE
feat: get all products in an organisation

### DIFF
--- a/src/controllers/ProductController.ts
+++ b/src/controllers/ProductController.ts
@@ -108,6 +108,151 @@ class ProductController {
 
   /**
    * @openapi
+   * /api/v1/organisation/{:id}/product/search:
+   *   get:
+   *     tags:
+   *       - Product API
+   *     summary: Get All products.
+   *     description: Get All products within an organisation.
+   *     parameters:
+   *       - name: org_id
+   *         in: path
+   *         required: true
+   *         description: ID of the organisation
+   *         schema:
+   *           type: string
+   *       - name: name
+   *         in: query
+   *         required: false
+   *         description: Name of the product
+   *         schema:
+   *           type: string
+   *       - name: category
+   *         in: query
+   *         required: false
+   *         description: Category of the product
+   *         schema:
+   *           type: string
+   *       - name: minPrice
+   *         in: query
+   *         required: false
+   *         description: Minimum price of the product
+   *         schema:
+   *           type: number
+   *       - name: maxPrice
+   *         in: query
+   *         required: false
+   *         description: Maximum price of the product
+   *         schema:
+   *           type: number
+   *       - name: page
+   *         in: query
+   *         required: false
+   *         description: Page number for pagination
+   *         schema:
+   *           type: number
+   *           default: 1
+   *       - name: limit
+   *         in: query
+   *         required: false
+   *         description: Number of results per page
+   *         schema:
+   *           type: number
+   *           default: 10
+   *     responses:
+   *       200:
+   *         description: Product search successful
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                   example: "Product search successful"
+   *                 data:
+   *                   type: object
+   *                   properties:
+   *                     pagination:
+   *                       type: object
+   *                       properties:
+   *                         total:
+   *                           type: number
+   *                         page:
+   *                           type: number
+   *                         limit:
+   *                           type: number
+   *                         totalPages:
+   *                           type: number
+   *                     products:
+   *                       type: array
+   *                       items:
+   *                         type: object
+   *                         properties:
+   *                           id:
+   *                             type: string
+   *                           name:
+   *                             type: string
+   *                           description:
+   *                             type: string
+   *                           price:
+   *                             type: number
+   *                           category:
+   *                             type: string
+   *                           status:
+   *                             type: string
+   *                           quantity:
+   *                             type: number
+   *                           created_at:
+   *                             type: string
+   *                             format: date-time
+   *                           updated_at:
+   *                             type: string
+   *                             format: date-time
+   *       400:
+   *         description: Invalid input or missing organisation ID
+   *       404:
+   *         description: No products found
+   */
+
+  public getProduct = async (
+    req: Request,
+    res: Response,
+    next: NextFunction,
+  ) => {
+    try {
+      const orgId = req.params.org_id;
+      const {
+        name,
+        category,
+        minPrice,
+        maxPrice,
+        page = 1,
+        limit = 10,
+      } = req.query as any;
+      const searchCriteria = {
+        name,
+        category,
+        minPrice: Number(minPrice),
+        maxPrice: Number(maxPrice),
+      };
+
+      const products = await this.productService.getProducts(
+        orgId,
+        searchCriteria,
+        Number(page),
+        Number(limit),
+      );
+      return res
+        .status(200)
+        .json({ message: "Product search successful", data: products });
+    } catch (error) {
+      next(error);
+    }
+  };
+
+  /**
+   * @openapi
    * /api/v1/products/{product_id}:
    *   delete:
    *     summary: Delete a product by its ID

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -17,6 +17,13 @@ productRouter.post(
   productController.createProduct,
 );
 
+productRouter.get(
+  "/organizations/:org_id/products/search",
+  authMiddleware,
+  validateUserToOrg,
+  productController.getProduct,
+);
+
 productRouter.delete(
   "/organizations/:org_id/products/:product_id",
   authMiddleware,

--- a/src/routes/product.ts
+++ b/src/routes/product.ts
@@ -8,6 +8,7 @@ import { adminOnly } from "../middleware";
 const productRouter = Router();
 const productController = new ProductController();
 
+// route
 productRouter.post(
   "/organizations/:org_id/products",
   validateProductDetails,

--- a/src/services/product.services.ts
+++ b/src/services/product.services.ts
@@ -105,6 +105,62 @@ export class ProductService {
       },
     };
   }
+
+  public async getProducts(
+    orgId: string,
+    query: {
+      name?: string;
+      category?: string;
+      minPrice?: number;
+      maxPrice?: number;
+    },
+    page: number = 1,
+    limit: number = 10,
+  ) {
+    const org = await this.organizationRepository.findOne({
+      where: { id: orgId },
+    });
+    if (!org) {
+      throw new ServerError(
+        "Unprocessable entity exception: Invalid organization credentials",
+      );
+    }
+
+    const { name, category, minPrice, maxPrice } = query;
+    const queryBuilder = this.productRepository
+      .createQueryBuilder("product")
+      .where("product.orgId = :orgId", { orgId });
+
+    if (name) {
+      queryBuilder.andWhere("product.name ILIKE :name", { name: `%${name}%` });
+    }
+    if (minPrice) {
+      queryBuilder.andWhere("product.price >= :minPrice", { minPrice });
+    }
+    if (maxPrice) {
+      queryBuilder.andWhere("product.price <= :maxPrice", { maxPrice });
+    }
+
+    const skip = (page - 1) * limit;
+    queryBuilder.skip(skip).take(limit);
+
+    const [products, total] = await queryBuilder.getManyAndCount();
+
+    return {
+      success: true,
+      statusCode: 200,
+      data: {
+        products,
+        pagination: {
+          total,
+          page,
+          limit,
+          totalPages: Math.ceil(total / limit),
+        },
+      },
+    };
+  }
+
   public async deleteProduct(org_id: string, product_id: string) {
     try {
       const entities = await this.checkEntities({

--- a/src/test/product.spec.ts
+++ b/src/test/product.spec.ts
@@ -135,6 +135,123 @@ describe("ProductService", () => {
       ).rejects.toThrow(ServerError);
     });
   });
+
+  describe("getProducts", () => {
+    it("should search products successfully", async () => {
+      const mockOrgId = "1";
+      const mockQuery = { name: "Test", minPrice: 0, maxPrice: 100 };
+      const mockOrg = { id: "1", name: "Test Organization" };
+      const mockProducts = [{ id: "1", name: "Test Product", price: 50 }];
+      const mockTotalCount = 2;
+
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest
+          .fn()
+          .mockResolvedValue([mockProducts, mockTotalCount]),
+      };
+
+      productRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(mockQueryBuilder);
+      organizationRepository.findOne = jest.fn().mockResolvedValue(mockOrg);
+
+      const result = await productService.getProducts(mockOrgId, mockQuery);
+      expect(result.success).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.data.products).toEqual(mockProducts);
+      expect(result.data.pagination.total).toBe(mockTotalCount);
+      expect(result.data.pagination.page).toBe(1);
+      expect(result.data.pagination.limit).toBe(10);
+    });
+    it("should search products successfully with specified pagination", async () => {
+      const mockOrgId = "1";
+      const mockQuery = { name: "Test", minPrice: 0, maxPrice: 100 };
+      const mockPage = 2;
+      const mockLimit = 5;
+      const mockOrg = { id: "1", name: "Test Organization" };
+      const mockProducts = [{ id: "1", name: "Test Product", price: 50 }];
+      const mockTotalCount = 5;
+
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest
+          .fn()
+          .mockResolvedValue([mockProducts, mockTotalCount]),
+      };
+
+      productRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(mockQueryBuilder);
+      organizationRepository.findOne = jest.fn().mockResolvedValue(mockOrg);
+
+      const result = await productService.getProducts(
+        mockOrgId,
+        mockQuery,
+        mockPage,
+        mockLimit,
+      );
+      expect(result.success).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.data.pagination.total).toBe(mockTotalCount);
+      expect(result.data.pagination.page).toBe(mockPage);
+      expect(result.data.pagination.limit).toBe(mockLimit);
+    });
+
+    it("should return an empty product array when product is not found", async () => {
+      const mockOrgId = "1";
+      const mockQuery = { name: "Nonexistent Product" };
+      const mockOrg = { id: "1", name: "Test Organization" };
+      const mockTotalCount = 0;
+      const mockProducts = [];
+
+      const mockQueryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      };
+
+      productRepository.createQueryBuilder = jest
+        .fn()
+        .mockReturnValue(mockQueryBuilder);
+      organizationRepository.findOne = jest.fn().mockResolvedValue(mockOrg);
+
+      const result = await productService.getProducts(mockOrgId, mockQuery);
+      expect(result.success).toBe(true);
+      expect(result.statusCode).toBe(200);
+      expect(result.data.pagination.total).toBe(mockTotalCount);
+      expect(result.data.products).toStrictEqual(mockProducts);
+    });
+
+    it("should throw a ServerError when organization is not found", async () => {
+      const mockOrgId = "nonexistentOrg";
+      const mockQuery = { name: "Test Product" };
+
+      organizationRepository.findOne = jest.fn().mockResolvedValue(undefined);
+
+      await expect(
+        productService.getProducts(mockOrgId, mockQuery),
+      ).rejects.toThrow(ServerError);
+    });
+
+    it("should throw a server error when organization is not found", async () => {
+      const mockOrgId = "nonexistentOrg";
+      const mockQuery = { name: "Test Product" };
+      organizationRepository.findOne = jest.fn().mockResolvedValue(undefined);
+      await expect(
+        productService.getProducts(mockOrgId, mockQuery),
+      ).rejects.toThrow(ServerError);
+    });
+  });
+
   describe("deleteProduct", () => {
     it("should delete the product from the organization", async () => {
       const org_id = "org123";


### PR DESCRIPTION
## Description
This PR introduces a new endpoint to search for products within an organization based on various criteria.

## How should this be manually tested?
Send a GET request to `/api/v1/organizations/org_id/products/search` with the following query parameters:
- name (optional): The name of the product
- category (optional): The category of the product
- minPrice (optional): Minimum price of the product
- maxPrice (optional): Maximum price of the product
- page (optional): Page number for pagination (default: 1)
- limit (optional): Number of results per page (default: 10)
```json
GET /api/v1/organizations/:org_id/products/search?name=ProductA&minPrice=10&maxPrice=100&page=1&limit=10
```
- Replace :org_id with the actual organization ID.
- Ensure the query parameters are correctly used to filter and paginate the results.

## Checklist of what you did:
- [x] Implemented GET `/api/v1/organizations/org_id/products/search` endpoint
- [x] Added functionality to search products based on name, category, minPrice, maxPrice, and pagination parameters
- [x] Updated OpenAPI documentation to reflect the endpoint's functionality
- [x] Ensured authentication using JWT tokens
- [x] Wrote unit and integration tests for the product search endpoint

## Reference Issues
[FEAT] Implement GET All Products in an Organisation Endoint with Pagination (Page, Limit, Offset) #142 
